### PR TITLE
resolves #65

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -81,6 +81,7 @@ var cliOptions = {
 BridgeCliParse(cliOptions)
 
 var cliConfiguration = BridgeCliParse().getConfiguration()
+BridgeLogManager.passCliConf(cliConfiguration)
 
 console.log('Please wait...')
 

--- a/lib/bridge-log-manager.js
+++ b/lib/bridge-log-manager.js
@@ -14,6 +14,7 @@ const LogEmitter = new EventEmitter()
 LogEmitter.setMaxListeners(1)
 
 var logsContainer = []
+var cliConfiguration
 
 function BridgeLogManager () {
   this.contractInstance = OracleInstance().getContractInstance()
@@ -127,7 +128,14 @@ const parseLog = function (err, log) {
 
   if (logArgs['gasPrice']) logObj['parsed_log'].gasPrice = logArgs['gasPrice'].toNumber()
 
-  logObj['block_timestamp'] = BlockchainInterface().inter.getBlock(log['blockHash']).timestamp
+  try {
+    logObj['block_timestamp'] = BlockchainInterface().inter.getBlock(log['blockHash']).timestamp
+  } catch (e) {
+    // exception for dev chain resets (ganache)
+    if (e.message === 'Key not found in database' &&
+      cliConfiguration.dev === true) return
+    else throw e
+  }
 
   emitsNewLog(null, logObj)
 }
@@ -146,6 +154,10 @@ const removeAllLogs = function (e, type) {
   } else process.exit()
 }
 
+const passCliConf = function (cliConf) {
+  cliConfiguration = cliConf
+}
+
 process.on('SIGINT', function () {
   removeAllLogs(null, {'clean': true})
 })
@@ -155,3 +167,4 @@ process.on('uncaughtException', removeAllLogs)
 module.exports.init = singleton(BridgeLogManager)
 module.exports.events = LogEmitter
 module.exports.removeAllLogs = removeAllLogs
+module.exports.passCliConf = passCliConf


### PR DESCRIPTION
Bug referenced in https://github.com/oraclize/ethereum-bridge/issues/65. Will ignore web3 error if dev flag passed, which arises from expected block hash not exisitng, which can occur in dev environments, using ganache which can rapidly switch between various blockchain snapshots.