### PR TITLE
[Fix] Change outdated `OraclizeAddrResolverI` to `OracleAddrResolverI` in log message

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ethereum-bridge -H localhost:8545 --broadcast -a 0
 
 #### Add a custom address resolver
 
-Add `OAR = OraclizeAddrResolverI(EnterYourOarCustomAddress);` to your contract constructor, example:
+Add `OAR = OracleAddrResolverI(EnterYourOarCustomAddress);` to your contract constructor, example:
 
 Where `EnterYourOarCustomAddress` is the address resolver generated when you have run the script
 ```
@@ -76,7 +76,7 @@ contract test() {
 
     function test() {
       // this is the constructor
-      OAR = OraclizeAddrResolverI(0xf0f20d1a90c618163d762f9f09baa003a60adeff);
+      OAR = OracleAddrResolverI(0xf0f20d1a90c618163d762f9f09baa003a60adeff);
     }
 
     ...

--- a/bridge.js
+++ b/bridge.js
@@ -652,7 +652,7 @@ function runLog () {
 
   var checksumOar = bridgeCore.ethUtil.toChecksumAddress(activeOracleInstance.oar)
   if (checksumOar === '0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475' && !isTestRpc) logger.info('you are using a deterministic OAR, you don\'t need to update your contract')
-  else console.log('\nPlease add this line to your contract constructor:\n\n' + 'OAR = OraclizeAddrResolverI(' + checksumOar + ');\n')
+  else console.log('\nPlease add this line to your contract constructor:\n\n' + 'OAR = OracleAddrResolverI(' + checksumOar + ');\n')
 
   logger.debug('starting the bridge log manager...')
   BridgeLogManager = BridgeLogManager.init()


### PR DESCRIPTION
This PR changes outdated `OraclizeAddrResolverI` to `OracleAddrResolverI` in log message.
It should close https://github.com/provable-things/ethereum-bridge/issues/80

Error message from solidity compiler when using `OraclizeAddrResolverI`:
![image](https://user-images.githubusercontent.com/33207565/120538874-48224800-c3e7-11eb-95bc-75d1ae039f9a.png)
